### PR TITLE
Fix typo: Specify TEMP_SENSOR_2

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -797,7 +797,7 @@
 
 #if ENABLED (TRIEX)
   #define TEMP_SENSOR_1 5
-  #define TEMP_SENSOR_1 5
+  #define TEMP_SENSOR_2 5
 #endif
 
 #define TEMP_SENSOR_3 0


### PR DESCRIPTION
This fixes a typo where TEMP_SENSOR_2 wasn't set. Instead, due te the typo TEMP_SENSOR_1 was set twice.

Haven't tested the change, I just came across this bug while reading the code.

### Requirements
n/a

### Description
This fixes a typo where TEMP_SENSOR_2 wasn't set. Instead, due te the typo TEMP_SENSOR_1 was set twice.

Haven't tested the change, I just came across this bug while reading the code.

### Benefits
Correctly configure the 2nd thermistor for triple extruder machines like the A10T and A20T.

### Configurations
n/a

### Related Issues
n/a
